### PR TITLE
Column Widths

### DIFF
--- a/GameList/ServerTabDesign_frm.Designer.cs
+++ b/GameList/ServerTabDesign_frm.Designer.cs
@@ -493,7 +493,6 @@
             // ColumnType
             // 
             this.ColumnType.Text = "Type";
-            this.ColumnType.Width = 76;
             // 
             // ColumnRules
             // 
@@ -503,17 +502,17 @@
             // ColumnMode
             // 
             this.ColumnMode.Text = "Mode";
-            this.ColumnMode.Width = 100;
+            this.ColumnMode.Width = 75;
             // 
             // ColumnState
             // 
             this.ColumnState.Text = "State";
-            this.ColumnState.Width = 106;
+            this.ColumnState.Width = 75;
             // 
             // ColumnPlayers
             // 
             this.ColumnPlayers.Text = "Players";
-            this.ColumnPlayers.Width = 254;
+            this.ColumnPlayers.Width = 273;
             // 
             // ServerInterface_frm
             // 


### PR DESCRIPTION
Shortened the columns for Type, State, & Mode in the Gamelist. Then
lengthened the column for Players to eliminate the horizontal scroll bar
and give more room for player names.
