### PR TITLE
Update Main_frm.cs

### DIFF
--- a/Windows/Main_frm.cs
+++ b/Windows/Main_frm.cs
@@ -162,7 +162,7 @@ namespace DevProLauncher.Windows
 
         private void siteBtn_Click(object sender, EventArgs e)
         {
-            Process.Start("http://devpro.org");
+            Process.Start("http://devpro.org/blog");
         }
 
         private void DeckBtn_Click(object sender, EventArgs e)


### PR DESCRIPTION
DevPro.org is the landing page for people looking for the download, after they download the client they will be looking for other types of content, this is where the /blog comes in. It provides the content they are looking for in addition to deeper navigation.

Compare runescape.com's landing page to after you have started using the game, it takes you to a news page instead.
