### PR TITLE
Logging, /me timestamp and tags

### DIFF
--- a/Helpers/ChatHelper.cs
+++ b/Helpers/ChatHelper.cs
@@ -27,11 +27,60 @@ namespace DevProLauncher.Helpers
             
             if ((CommandType)message.command == CommandType.Me)
             {
+                string LogFile = "";
+                string LogText = "";
+                string LogDir = @"Logs\";
+                if ((MessageType)message.type == MessageType.Message)
+                {
+                    LogFile = message.channel + DateTime.Now.ToString(".dd") + ".txt";
+                    LogText += DateTime.Now.ToString("[HH:mm] ");
+                    LogDir += @"Channel\" + DateTime.Now.ToString("MMMM_yyyy") + @"\";
+                }
+                else if ((MessageType)message.type == MessageType.PrivateMessage)
+                {
+                    LogFile = message.channel + ".txt";
+                    LogText += DateTime.Now.ToString("[dd/MM/yy | HH:mm] ");
+                    LogDir += @"PMs\";
+                }
+                else if ((MessageType)message.type == MessageType.Team)
+                {
+                    LogFile = "Team.txt";
+                    LogText += DateTime.Now.ToString("[HH:mm] ");
+                }
+                if (Program.Config.ShowTimeStamp)
+                {
+                    WriteText(window, DateTime.Now.ToString("[HH:mm] "), (Program.Config.ColorBlindMode ? Color.Black : Program.Config.NormalTextColor.ToColor()));
+                }
+                if (message.from.rank > 0)
+                {
+                    WriteText(window, "[", (Program.Config.ColorBlindMode ? Color.Black : Program.Config.NormalTextColor.ToColor()));
+                    if (message.from.rank == 1 || message.from.rank == 4)
+                    {
+                        WriteText(window, "Dev", (Program.Config.ColorBlindMode ? Color.Black : message.RankColor()));
+                        LogText += "[Dev]";
+                    }
+                    else if (message.from.rank == 2 || message.from.rank == 3)
+                    {
+                        WriteText(window, "Mod", (Program.Config.ColorBlindMode ? Color.Black : message.RankColor()));
+                        LogText += "[Mod]";
+                    }
+                    else if (message.from.rank == 99)
+                    {
+                        LogText += "[Dev]";
+                        WriteText(window, "Dev", (Program.Config.ColorBlindMode ? Color.Black : message.RankColor()));
+                    }
+                    WriteText(window, "]", (Program.Config.ColorBlindMode ? Color.Black : Program.Config.NormalTextColor.ToColor()));
+                }
                 WriteText(window, message.message, Program.Config.MeMsgColor.ToColor());
+                LogText += message.message.Trim();
+                if (LogFile != "")
+                    if (!Directory.Exists(LogDir))
+                        Directory.CreateDirectory(LogDir);
+                File.AppendAllText(LogDir + LogFile, LogText + Environment.NewLine);
             }
             else if ((MessageType)message.type == MessageType.Team && (CommandType)message.command == CommandType.TeamServerMessage)
             {
-                WriteText(window, "[TeamMessage] " + message.message,(Program.Config.ColorBlindMode ? Color.Black : Program.Config.ServerMsgColor.ToColor()));
+                WriteText(window, DateTime.Now.ToString("[HH:mm]") + "[TeamMessage] " + message.message,(Program.Config.ColorBlindMode ? Color.Black : Program.Config.ServerMsgColor.ToColor()));
             }
             else if ((MessageType)message.type == MessageType.Message || (MessageType)message.type == MessageType.PrivateMessage || (MessageType)message.type == MessageType.Team)
             {
@@ -87,18 +136,16 @@ namespace DevProLauncher.Helpers
                 //    FormatText(message.message.Trim(), window);
                 string LogFile = "";
                 string LogDirectory = @"Logs\";
-                if (!Directory.Exists(LogDirectory))
-                    Directory.CreateDirectory(LogDirectory);
                 if ((MessageType)message.type == MessageType.Message)
                 {
-                    LogDirectory += @"Channel\" + DateTime.Now.ToString("MMMM_yyyy") + @"\"; ;
-                    LogText += DateTime.Now.ToString("[HH:mm]");
+                    LogDirectory += @"Channel\" + DateTime.Now.ToString("MMMM_yyyy") + @"\";
+                    LogText = DateTime.Now.ToString("[HH:mm] ") + LogText;
                     LogFile = message.channel + DateTime.Now.ToString(".dd") + ".txt";
                 }
                 else if ((MessageType)message.type == MessageType.PrivateMessage) 
                 {
                     LogDirectory += @"PMs\"; ;
-                    LogText += DateTime.Now.ToString("[dd MM yy | HH:mm] ");
+                    LogText = DateTime.Now.ToString("[dd/MM/yy | HH:mm] ") + LogText;
                     LogFile = message.channel + ".txt";
                 }
                 else if ((MessageType)message.type == MessageType.Team)
@@ -112,6 +159,10 @@ namespace DevProLauncher.Helpers
             }
             else if ((MessageType)message.type == MessageType.System || (MessageType)message.type == MessageType.Server)
             {
+                if (Program.Config.ShowTimeStamp)
+                {
+                    WriteText(window, DateTime.Now.ToString("[HH:mm] "), (Program.Config.ColorBlindMode ? Color.Black : Program.Config.NormalTextColor.ToColor()));
+                }
                 WriteText(window,"[", (Program.Config.ColorBlindMode ? Color.Black : Program.Config.NormalTextColor.ToColor()));
                 WriteText(window, ((MessageType)message.type).ToString() ,(Program.Config.ColorBlindMode ? Color.Black : message.MessageColor()));
                 WriteText(window, "]: ", (Program.Config.ColorBlindMode ? Color.Black : Program.Config.NormalTextColor.ToColor()));


### PR DESCRIPTION
/me now shows timestamp, and the Dev/Mod tags.
Server messages are timestamped.
Fixed logging where it wasn't logging the /me commands.
